### PR TITLE
demux: If there is no stream, there are no extended controls.

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -3115,7 +3115,7 @@ static struct demuxer *open_given_type(struct mpv_global *global,
         .access_references = opts->access_references,
         .events = DEMUX_EVENT_ALL,
         .duration = -1,
-        .extended_ctrls = stream->extended_ctrls,
+        .extended_ctrls = stream ? stream->extended_ctrls : 0,
     };
 
     struct demux_internal *in = demuxer->in = talloc_ptrtype(demuxer, in);


### PR DESCRIPTION
Fixes SIGSEGV e.g. for youtube-dl streams.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
